### PR TITLE
Update usaepay.php

### DIFF
--- a/CRM/Core/Payment/usaepay.php
+++ b/CRM/Core/Payment/usaepay.php
@@ -82,8 +82,8 @@ class CRM_Core_Payment_usaepay extends CRM_Core_Payment {
       $params['billing_middle_name'],
       $params['billing_last_name']
     );
-    $exp_month = str_pad(((string) $params['credit_card_exp_date']['M']), 2, 0, STR_PAD_LEFT);
-    $exp_year = substr(((string) $params['credit_card_exp_date']['Y']), -2);
+    $exp_year = substr($params['year'], 2, 2);
+    $exp_month = sprintf('%02d', (int) $params['month']);
 
     $tran = new umTransaction;
 


### PR DESCRIPTION
Right now on PHP 8+ it errors out since the month is being passed as 00 instead of the actual month in the form,
Changing it to this allowed it to go through correctlySet expiration parameters so it get's passed correctly.